### PR TITLE
Fix ipadic charset and update modules

### DIFF
--- a/io.github.ripose_jp.Memento.metainfo.xml
+++ b/io.github.ripose_jp.Memento.metainfo.xml
@@ -5,6 +5,9 @@
  <project_license>GPL-2.0</project_license>
  <name>memento</name>
  <summary>An mpv-based video player for studying Japanese</summary>
+ <developer id="io.github.ripose_jp">
+  <name>Ripose</name>
+ </developer>
  <launchable type="desktop-id">io.github.ripose_jp.Memento.desktop</launchable>
  <translation type="gettext">memento</translation>
  <content_rating type="oars-1.1" />

--- a/io.github.ripose_jp.Memento.yml
+++ b/io.github.ripose_jp.Memento.yml
@@ -731,8 +731,8 @@ modules:
           type: git
           tag-pattern: ^v([\d.]+)$
       - type: file
-        path: io.github.ripose_jp.Memento.appdata.xml
+        path: io.github.ripose_jp.Memento.metainfo.xml
       - type: patch
         path: patches/memento-fix-screensaver.patch
     post-install:
-      - install -Dm644 $FLATPAK_BUILDER_BUILDDIR/$FLATPAK_ID.appdata.xml /app/share/metainfo/$FLATPAK_ID.appdata.xml
+      - install -Dm644 $FLATPAK_BUILDER_BUILDDIR/$FLATPAK_ID.metainfo.xml /app/share/metainfo/$FLATPAK_ID.metainfo.xml

--- a/io.github.ripose_jp.Memento.yml
+++ b/io.github.ripose_jp.Memento.yml
@@ -688,7 +688,7 @@ modules:
       - /bin
       - /include
       - /libexec/mecab/mecab-*
-    build-options:
+    config-opts:
       - --with-charset=utf-8
     sources:
       - type: archive
@@ -705,7 +705,7 @@ modules:
       - /bin
       - /include
       - /libexec/mecab/mecab-*
-    build-options:
+    config-opts:
       - --with-charset=utf-8
     sources:
       - type: archive

--- a/io.github.ripose_jp.Memento.yml
+++ b/io.github.ripose_jp.Memento.yml
@@ -70,8 +70,8 @@ modules:
     sources:
       - type: archive
         archive-type: tar
-        url: https://download.samba.org/pub/samba/stable/samba-4.19.4.tar.gz
-        sha256: 4026d93b866db198c8ca1685b0f5d52793f65c6e63cb364163af661fdff0968c
+        url: https://download.samba.org/pub/samba/stable/samba-4.19.5.tar.gz
+        sha256: 0e2405b4cec29d0459621f4340a1a74af771ec7cffedff43250cad7f1f87605e
         x-checker-data:
           type: html
           url: https://download.samba.org/pub/samba/stable/?C=M;O=D
@@ -124,7 +124,7 @@ modules:
         mirror-urls:
           - https://luajit.org/git/luajit.git
         disable-shallow-clone: true
-        commit: 343ce0edaf3906a62022936175b2f5410024cbfc
+        commit: d06beb0480c5d1eb53b3343e78063950275aa281
         x-checker-data:
           type: json
           url: https://api.github.com/repos/LuaJIT/LuaJIT/commits
@@ -145,8 +145,8 @@ modules:
       - install yt-dlp /app/bin
     sources:
       - type: archive
-        url: https://github.com/yt-dlp/yt-dlp/releases/download/2023.12.30/yt-dlp.tar.gz
-        sha256: 5408fe5d12cd1c430ee10346770e3d60baad5c63a38b41c8967005e4956780a7
+        url: https://github.com/yt-dlp/yt-dlp/releases/download/2024.03.10/yt-dlp.tar.gz
+        sha256: 1db8eade9e860543b655f5f973e26727ac2cc20874dc6fed9a3e78a4a05ee989
         x-checker-data:
           type: json
           url: https://api.github.com/repos/yt-dlp/yt-dlp/releases/latest
@@ -405,7 +405,7 @@ modules:
     sources:
       - type: git
         url: https://code.videolan.org/videolan/x264.git
-        commit: 4815ccadb1890572f2bf8b9d9553d56f6c9122ad
+        commit: 585e01997f0c7e6d72c8ca466406d955c07de912
         # Every commit to the master branch is considered a release
         # https://code.videolan.org/videolan/x264/-/issues/35
         x-checker-data:
@@ -478,8 +478,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/libjxl/libjxl.git
-        tag: v0.9.1
-        commit: b8ceae3a6e9d0ffd9efebcbdd04322fcfc502eed
+        tag: v0.10.2
+        commit: e1489592a770b989303b0edc5cc1dc447bbe0515
         disable-shallow-clone: true
         x-checker-data:
           type: git
@@ -551,8 +551,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/vapoursynth/vapoursynth.git
-        tag: R65
-        commit: 3157049549a0940359b37004aeeeebd8f1db665e
+        tag: R66
+        commit: fe6c67cdb17f41160c79434f0240077f74de9fd1
         x-checker-data:
           type: git
           tag-pattern: ^R([\d.]+)$
@@ -616,8 +616,8 @@ modules:
             #  tag-pattern: ^sdk-([\d.]+)$
           - type: git
             url: https://github.com/KhronosGroup/glslang.git
-            tag: 14.0.0
-            commit: a91631b260cba3f22858d6c6827511e636c2458a
+            tag: 14.1.0
+            commit: ee2f5d09eaf8f4e8d0d598bd2172fce290d4ca60
             dest: third_party/glslang
             x-checker-data:
               type: git
@@ -658,8 +658,8 @@ modules:
       - -DCMAKE_BUILD_TYPE=RelWithDebInfo
     sources:
       - type: archive
-        url: https://libzip.org/download/libzip-1.10.0.tar.xz
-        sha256: cd2a7ac9f1fb5bfa6218272d9929955dc7237515bba6e14b5ad0e1d1e2212b43
+        url: https://libzip.org/download/libzip-1.10.1.tar.xz
+        sha256: dc3c8d5b4c8bbd09626864f6bcf93de701540f761d76b85d7c7d710f4bd90318
         x-checker-data:
           type: anitya
           project-id: 10649


### PR DESCRIPTION
ipadic was being compiled with the EUC-JP charset, which is incompatible with UTF-8 systems. This means that deconjugation before searching has never worked in the Flatpak version of Memento. This is a huge mistake, with a thankfully easy fix. Changes the `build-options` section of the manifest to `config-opts` which fixes the issue.